### PR TITLE
chore: remove cache

### DIFF
--- a/.github/workflows/schema_validation.yml
+++ b/.github/workflows/schema_validation.yml
@@ -35,20 +35,10 @@ jobs:
       - name: Check out code into the policy directory
         uses: actions/checkout@v2
 
-      - name: Cache CQ
-        id: cache-cq-binary
-        uses: actions/cache@v2
-        with:
-          path: cloudquery
-          key: ${{ runner.os }}-${{ hashFiles('cloudquery') }}
-
       - name: Download Cloudquery
-        if: steps.cache-cq-binary.cache-hit != 'true'
         run: |
           curl -L https://github.com/cloudquery/cloudquery/releases/latest/download/cloudquery_Linux_x86_64 -o cloudquery
           chmod a+x cloudquery
-        env:
-          OS: Linux
 
       - name: Build Schema
         run: |


### PR DESCRIPTION
Ignore this Im Just testing https://github.com/cloudquery-policies/.github

I don't think this caching is working because we are using latest and not a specific version which means there is no way of knowing when to invalidate the cache. 

There is a way to implement it by checking what is the latest version but this is more complex and not needed right now.